### PR TITLE
Add the commit message itself to the feed

### DIFF
--- a/commits/index.php
+++ b/commits/index.php
@@ -44,7 +44,8 @@ if ($_SERVER['QUERY_STRING'] == 'rss') {
 ?>
     <item>
       <title><?php echo htmlentities($description, ENT_QUOTES); ?></title>
-      <description><?php echo $commit['project'] . ' (' . substr($commit['revision_sha'], 0, 7) . ') by ' . $commit['author']; ?>.</description>
+      <description><?php echo $commit['project'] . ' (' . substr($commit['revision_sha'], 0, 7) . ') by ' . $commit['author']; ?>.<br/>
+      <?php echo htmlspecialchars($message); ?></description>
       <link><?php echo htmlentities($commit['url']); ?></link>
       <guid><?php echo htmlentities($commit['url']); ?></guid>
       <pubDate><?php echo date(DateTime::RSS, strtotime($commit['revision_date'])); ?></pubDate>


### PR DESCRIPTION
This only shows "Chromium (b25744b) by haraken@chromium.org." instead of the actual commit message. It would be helpful to get the actual commit message.
I find myself lots of times go to the URL in order to read the commit message and see the issues.
Possible next step - linking BUG=23232, v8:2323, skia:223 to the respective issue tracker detail pages.


Untested, sorry. :(