### PR TITLE
Pad value should be written in network byte order

### DIFF
--- a/tests/cases/webcrypto-push-encryption.js
+++ b/tests/cases/webcrypto-push-encryption.js
@@ -130,7 +130,7 @@ var WebPushCryptographer = function () {
         var nonce = _ref4[1];
 
         var record = new Uint8Array(2 + paddingBytes + plaintext.byteLength);
-        record.set([paddingBytes & 0xFF, paddingBytes >> 8]);
+        record.set([paddingBytes >> 8, paddingBytes & 0xFF]);
         record.fill(0, 2 /* sizeof(uint16_t) */, 2 + paddingBytes);
         record.set(new Uint8Array(plaintext), 2 + paddingBytes);
 


### PR DESCRIPTION
I'm not sure where the original source is (the one you're babelifying).