### PR TITLE
Show notification reply even when action is empty

### DIFF
--- a/tests/notification-generator/sw.js
+++ b/tests/notification-generator/sw.js
@@ -55,7 +55,7 @@ self.addEventListener('notificationclick', function(event) {
   if (options.action == 'message') {
     firstWindowClient().then(function(client) {
       var message = 'Clicked on "' + notification.title + '"';
-      if (event.action) {
+      if (event.action || event.reply) {
         message += ' (action: "' + event.action + '", reply: ';
         message += event.reply === null ? 'null' : '"' + event.reply + '"';
         message += ')';


### PR DESCRIPTION
It appears the Notification event does not have "action" set when "reply" is set.