### PR TITLE
Update loadSwitchFiles to reference main branch

### DIFF
--- a/services/services/command-line-flags/CommandLineFlags.php
+++ b/services/services/command-line-flags/CommandLineFlags.php
@@ -379,7 +379,7 @@ class CommandLineFlags extends Service {
 
         chdir(Configuration::$chromiumCheckout);
         {
-            $files = preg_split('/\s+/s', shell_exec('git ls-files --with-tree origin/master -x "*switches.cc" --ignored'), 0, PREG_SPLIT_NO_EMPTY);
+            $files = preg_split('/\s+/s', shell_exec('git ls-files --with-tree origin/main -x "*switches.cc" --ignored'), 0, PREG_SPLIT_NO_EMPTY);
             foreach ($files as $filename) {
                 $absolute = Configuration::$chromiumCheckout . '/' . $filename;
                 if (!file_exists($absolute)) {


### PR DESCRIPTION
Issue #49 notes that the [List of Command Line Switches](https://peter.sh/experiments/chromium-command-line-switches/) page states that the "Last automated update occurred on 2020-08-12". @confor posited in [this comment](https://github.com/beverloo/peter.sh/issues/49#issuecomment-1126904758) that this may be because Chromium switched from `master` to `main`. 

While this doesn't quite align with the cutover dates outlined in [this dev-infra thread](https://groups.google.com/a/chromium.org/g/infra-dev/c/VnBzAvhcngw), it seemed like it might still be a good idea to update the branch referenced in `loadSwitchFiles()`.