### PR TITLE
add --cached to ls-files cmd

### DIFF
--- a/services/services/command-line-flags/CommandLineFlags.php
+++ b/services/services/command-line-flags/CommandLineFlags.php
@@ -379,7 +379,7 @@ class CommandLineFlags extends Service {
 
         chdir(Configuration::$chromiumCheckout);
         {
-            $files = preg_split('/\s+/s', shell_exec('git ls-files --with-tree origin/main -x "*switches.cc" --ignored'), 0, PREG_SPLIT_NO_EMPTY);
+            $files = preg_split('/\s+/s', shell_exec('git ls-files --with-tree origin/main -x "*switches.cc" --ignored --cached'), 0, PREG_SPLIT_NO_EMPTY);
             foreach ($files as $filename) {
                 $absolute = Configuration::$chromiumCheckout . '/' . $filename;
                 if (!file_exists($absolute)) {


### PR DESCRIPTION
tbh I don't know ls-files well, but while reading this file I tried the command here and it didn't work locally.
I imagine if the `git` on your server updates, it'd also fail for similar reasons.


<img width="598" alt="image" src="https://user-images.githubusercontent.com/39191/185676861-7f517343-9e93-4536-9d09-506b5dde0faa.png">

My interpretation of the ls-[files docs](https://git-scm.com/docs/git-ls-files/2.18.0) suggests that this has been required since a 2018-ish `git`.

Also.. i have no idea if this addition is backwards compatible... 