### PR TITLE
Add "Request permission" button

### DIFF
--- a/tests/notification-generator/index.html
+++ b/tests/notification-generator/index.html
@@ -107,6 +107,11 @@
 
           generator.registerServiceWorker('/notification-generator/');
           generator.requestPermission();
+
+          var requestButton = document.getElementById('action-request');
+          requestButton.addEventListener('click', function() {
+            generator.requestPermission();
+          });
         });
       </script>
       <div id="test-case" class="test-case">
@@ -301,6 +306,7 @@
         </ol>
 
         <p>
+          <button id="action-request">Request permission</button>
           <button id="action-reset">Reset</button>
           <button id="action-display">Display the notification</button>
           <button id="action-get-displayed">Get displayed notifications</button>

--- a/tests/push-message-generator/index.html
+++ b/tests/push-message-generator/index.html
@@ -57,6 +57,11 @@
 
           generator.registerServiceWorker('/push-message-generator/');
           generator.requestPermission();
+
+          var requestButton = document.getElementById('action-request');
+          requestButton.addEventListener('click', function() {
+            generator.requestPermission();
+          });
         });
       </script>
       <div id="test-case" class="test-case">
@@ -89,6 +94,7 @@
         </ol>
 
         <p>
+          <button id="action-request">Request permission</button>
           <button id="action-subscribe">Subscribe</button>
           <button id="action-unsubscribe">Unsubscribe</button> —
           <button id="action-display">Display subscription</button>


### PR DESCRIPTION
In Safari notification prompting can only be done from a user gesture. So I've added a "Request permission" button.