### PR TITLE
Fix notifications work on iOS and iPadOS

### DIFF
--- a/tests/notification-generator/index.html
+++ b/tests/notification-generator/index.html
@@ -118,7 +118,7 @@
           <li>Unable to execute the JavaScript code.</li>
         </ul>
         <ul class="notes">
-          <li>On iOS, requires the web app to be added to the home screen.</li>
+          <li>On iOS and iPadOS, requires the web app to be added to the home screen.</li>
         </ul>
 
         <h2>Visual settings</h2>

--- a/tests/notification-generator/index.html
+++ b/tests/notification-generator/index.html
@@ -106,7 +106,6 @@
           }
 
           generator.registerServiceWorker('/notification-generator/');
-          generator.requestPermission();
 
           var requestButton = document.getElementById('action-request');
           requestButton.addEventListener('click', function() {
@@ -117,6 +116,9 @@
       <div id="test-case" class="test-case">
         <ul id="requirements" class="requirements">
           <li>Unable to execute the JavaScript code.</li>
+        </ul>
+        <ul class="notes">
+          <li>On iOS, requires the web app to be added to the home screen.</li>
         </ul>
 
         <h2>Visual settings</h2>

--- a/tests/push-message-generator/index.html
+++ b/tests/push-message-generator/index.html
@@ -56,7 +56,6 @@
               /* display-msg */ document.getElementById('action-display-msg'));
 
           generator.registerServiceWorker('/push-message-generator/');
-          generator.requestPermission();
 
           var requestButton = document.getElementById('action-request');
           requestButton.addEventListener('click', function() {
@@ -67,6 +66,9 @@
       <div id="test-case" class="test-case">
         <ul id="requirements" class="requirements">
           <li>Unable to execute the JavaScript code.</li>
+        </ul>
+        <ul class="notes">
+          <li>On iOS, requires the web app to be added to the home screen.</li>
         </ul>
 
         <h2>Subscription settings</h2>

--- a/tests/push-message-generator/index.html
+++ b/tests/push-message-generator/index.html
@@ -68,7 +68,7 @@
           <li>Unable to execute the JavaScript code.</li>
         </ul>
         <ul class="notes">
-          <li>On iOS, requires the web app to be added to the home screen.</li>
+          <li>On iOS and iPadOS, requires the web app to be added to the home screen.</li>
         </ul>
 
         <h2>Subscription settings</h2>

--- a/tests/resources/style.css
+++ b/tests/resources/style.css
@@ -42,6 +42,12 @@
   background-color: rgba(255, 0, 0, .1);
 }
 
+.notes {
+  margin: 0 0 8px 0;
+  padding-top: 8px; padding-bottom: 8px;
+  background-color: rgba(255, 255, 0, .1);
+}
+
 .dialog-content { display: none; }
 
 .no-display { display: none; }


### PR DESCRIPTION
Web push notifications are available for web apps on iOS and iPadOS since version 16.4 beta 1 (official announcement: https://webkit.org/blog/13878/web-push-for-web-apps-on-ios-and-ipados/), but web app must be installed to home screen. Also, notification prompting must only be done from a user gesture. If it was done from page loading, then further notification prompting for some reason don't work, even if they were done from a user gesture.