### PR TITLE
Add support for Edge, Safari, and Meta Quest Browser

### DIFF
--- a/tests/notification-generator/index.html
+++ b/tests/notification-generator/index.html
@@ -119,6 +119,10 @@
         </ul>
         <ul class="notes">
           <li>On iOS and iPadOS, requires the web app to be added to the home screen.</li>
+          <li>
+            On Meta Quest, requires the web app to be
+            <a href="https://web.dev/pwas-on-oculus-2/#packaging-pwas-with-pwabuilder" target="_blank">packaged</a>.
+          </li>
         </ul>
 
         <h2>Visual settings</h2>

--- a/tests/push-message-generator/index.html
+++ b/tests/push-message-generator/index.html
@@ -69,6 +69,10 @@
         </ul>
         <ul class="notes">
           <li>On iOS and iPadOS, requires the web app to be added to the home screen.</li>
+          <li>
+            On Meta Quest, requires the web app to be
+            <a href="https://web.dev/pwas-on-oculus-2/#packaging-pwas-with-pwabuilder" target="_blank">packaged</a>.
+          </li>
         </ul>
 
         <h2>Subscription settings</h2>

--- a/tests/push.php
+++ b/tests/push.php
@@ -6,14 +6,14 @@
 // List of endpoints that can be used by the Push Generator. Please send a PR
 // on GitHub (beverloo/peter.sh) if yours isn't listed.
 $endpointWhitelist = [
-  'android.googleapis.com/gcm/send',
-  'fcm.googleapis.com',
-  'jmt17.google.com',
-  'updates.push.services.mozilla.com',
-  'updates-autopush.stage.mozaws.net',
+  'https://android.googleapis.com/gcm/send',
+  'https://fcm.googleapis.com',
+  'https://jmt17.google.com',
+  'https://updates.push.services.mozilla.com',
+  'https://updates-autopush.stage.mozaws.net',
+  'https://graph.facebook.com/rl_push_send',
   '.push.apple.com',
   '.notify.windows.com',
-  'graph.facebook.com/rl_push_send',
 ];
 
 if (file_exists(__DIR__ . '/push.private.php'))

--- a/tests/push.php
+++ b/tests/push.php
@@ -6,12 +6,13 @@
 // List of endpoints that can be used by the Push Generator. Please send a PR
 // on GitHub (beverloo/peter.sh) if yours isn't listed.
 $endpointWhitelist = [
-  'https://android.googleapis.com/gcm/send',
-  'https://fcm.googleapis.com/',
-  'https://jmt17.google.com/',
-  'https://updates.push.services.mozilla.com/wpush/v2/',
-  'https://updates.push.services.mozilla.com/push/',
-  'https://updates-autopush.stage.mozaws.net',
+  'android.googleapis.com/gcm/send',
+  'fcm.googleapis.com',
+  'jmt17.google.com',
+  'updates.push.services.mozilla.com',
+  'updates-autopush.stage.mozaws.net',
+  '.push.apple.com',
+  '.notify.windows.com',
 ];
 
 if (file_exists(__DIR__ . '/push.private.php'))
@@ -33,12 +34,13 @@ function toHeaderName($name) {
 function isWhitelisted($endpoint) {
   global $endpointWhitelist;
 
-  $filtered = array_filter($endpointWhitelist, function($entry) use ($endpoint) {
-    return substr($endpoint, 0, strlen($entry)) == $entry ||
-           strpos($endpoint, $entry) !== false;
-  });
+  foreach ($endpointWhitelist as $whitelisted) {
+    if (str_contains($endpoint, $whitelisted)) {
+      return true;
+    }
+  }
 
-  return !!count($filtered);
+  return false;
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/push.php
+++ b/tests/push.php
@@ -5,15 +5,15 @@
 
 // List of endpoints that can be used by the Push Generator. Please send a PR
 // on GitHub (beverloo/peter.sh) if yours isn't listed.
-$endpointWhitelist = [
-  'https://android.googleapis.com/gcm/send',
-  'https://fcm.googleapis.com',
-  'https://jmt17.google.com',
-  'https://updates.push.services.mozilla.com',
-  'https://updates-autopush.stage.mozaws.net',
-  'https://graph.facebook.com/rl_push_send',
-  '.push.apple.com',
-  '.notify.windows.com',
+$endpointPatterns = [
+  '/^https:\/\/android\.googleapis\.com\/gcm\/send.*/',
+  '/^https:\/\/fcm\.googleapis\.com.*/',
+  '/^https:\/\/jmt17\.google\.com.*/',
+  '/^https:\/\/updates\.push\.services\.mozilla\.com.*/',
+  '/^https:\/\/updates-autopush\.stage\.mozaws\.net.*/',
+  '/^https:\/\/graph\.facebook\.com\/rl_push_send.*/',
+  '/^https:\/\/.*\.push\.apple\.com.*/',
+  '/^https:\/\/.*\.notify\.windows\.com.*/',
 ];
 
 if (file_exists(__DIR__ . '/push.private.php'))
@@ -33,10 +33,10 @@ function toHeaderName($name) {
 
 // Determines if the |$endpoint| contains a whitelisted URL.
 function isWhitelisted($endpoint) {
-  global $endpointWhitelist;
+  global $endpointPatterns;
 
-  foreach ($endpointWhitelist as $whitelisted) {
-    if (str_contains($endpoint, $whitelisted)) {
+  foreach ($endpointPatterns as $pattern) {
+    if (preg_match($pattern, $endpoint)) {
       return true;
     }
   }
@@ -58,10 +58,19 @@ $endpoint = $requestHeaders['x-endpoint'];
 $headers = [];
 
 if (!isWhitelisted($endpoint))
-  fatalError('403 Forbidden', 'The endpoint has not been whitelisted. Send a PR?');
+  fatalError(
+    '403 Forbidden',
+    'The endpoint has not been whitelisted. Send a PR to the https://github.com/beverloo/peter.sh/blob/master/tests/push.php file?'
+  );
 
-$optionalHeaders = ['Authorization', 'Content-Encoding', 'Content-Type', 'Crypto-Key', 'Encryption',
-                    'TTL'];
+$optionalHeaders = [
+  'Authorization',
+  'Content-Encoding',
+  'Content-Type',
+  'Crypto-Key',
+  'Encryption',
+  'TTL',
+];
 
 foreach ($optionalHeaders as $headerName) {
   $lowerCaseHeaderName = strtolower($headerName);

--- a/tests/push.php
+++ b/tests/push.php
@@ -13,6 +13,7 @@ $endpointWhitelist = [
   'updates-autopush.stage.mozaws.net',
   '.push.apple.com',
   '.notify.windows.com',
+  'graph.facebook.com/rl_push_send',
 ];
 
 if (file_exists(__DIR__ . '/push.private.php'))


### PR DESCRIPTION
This pull request adds `*.notify.windows.com`, `*.push.apple.com` and `graph.facebook.com/rl_push_send` to the endpoint allowlist.